### PR TITLE
Custom settings bundle name

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ update_settings_bundle(
 )
 ```
 
+#### Bundle name parameter
+
+By default, this action looks for a file called `Settings.bundle` in the project. To
+specify a different name for your settings bundle, use the `:bundle_name` option:
+```ruby
+update_settings_bundle(
+  xcodeproj: "MyProject.xcodeproj",
+  key: "CurrentAppVersion",
+  value: ":version (:build)",
+  bundle_name: "MySettings.bundle"
+)
+```
+
 ## Examples
 
 [SettingsBundleExample]: ./examples/SettingsBundleExample

--- a/lib/fastlane/plugin/settings_bundle/actions/update_settings_bundle_action.rb
+++ b/lib/fastlane/plugin/settings_bundle/actions/update_settings_bundle_action.rb
@@ -39,7 +39,7 @@ module Fastlane
         formatted_value = helper.formatted_value value, settings
 
         # raises
-        helper.update_settings_plist_title_setting project, file, key,
+        helper.update_settings_plist_title_setting project, params[:bundle_name], file, key,
                                                    formatted_value
       rescue => e
         UI.user_error! "#{e.message}\n#{e.backtrace}"
@@ -92,6 +92,12 @@ module Fastlane
                                description: "The plist file in the Settings.bundle to update",
                                   optional: true,
                              default_value: "Root.plist",
+                                      type: String),
+          FastlaneCore::ConfigItem.new(key: :bundle_name,
+                                  env_name: "SETTINGS_BUNDLE_BUNDLE_NAME",
+                               description: "The name of the settings bundle in the project (default Settings.bundle)",
+                                  optional: true,
+                             default_value: "Settings.bundle",
                                       type: String),
           FastlaneCore::ConfigItem.new(key: :target,
                                   env_name: "SETTINGS_BUNDLE_TARGET",

--- a/lib/fastlane/plugin/settings_bundle/actions/update_settings_bundle_action.rb
+++ b/lib/fastlane/plugin/settings_bundle/actions/update_settings_bundle_action.rb
@@ -146,6 +146,14 @@ module Fastlane
               value: ":version (:build)",
               target: "MyAppTarget"
             )
+          EOF,
+          <<-EOF
+            update_settings_bundle(
+              xcodeproj: "MyProject.xcodeproj",
+              key: "CurrentAppVersion",
+              value: ":version (:build)",
+              bundle_name: "MySettings.bundle"
+            )
           EOF
         ]
       end

--- a/lib/fastlane/plugin/settings_bundle/helper/settings_bundle_helper.rb
+++ b/lib/fastlane/plugin/settings_bundle/helper/settings_bundle_helper.rb
@@ -94,13 +94,14 @@ module Fastlane
         # on error.
         #
         # :project: An open Xcodeproj::Project, obtained from Xcodeproj::Project.open, e.g.
+        # :bundle_name: (String) Regex to identify the bundle to look for, usually Settings.bundle.
         # :file: A settings plist file in the Settings.bundle, usually "Root.plist"
         # :key: A valid NSUserDefaults key in the Settings.bundle
         # :value: A new value for the key
-        def update_settings_plist_title_setting(project, file, key, value)
-          settings_bundle = project.files.find { |f| f.path =~ /Settings.bundle/ }
+        def update_settings_plist_title_setting(project, bundle_name, file, key, value)
+          settings_bundle = project.files.find { |f| f.path =~ /#{bundle_name}/ }
 
-          raise "Settings.bundle not found in project" if settings_bundle.nil?
+          raise "#{bundle_name} not found in project" if settings_bundle.nil?
 
           # The #real_path method returns the full resolved path to the Settings.bundle
           settings_bundle_path = settings_bundle.real_path

--- a/spec/settings_bundle_helper_spec.rb
+++ b/spec/settings_bundle_helper_spec.rb
@@ -270,7 +270,39 @@ describe Fastlane::Helper::SettingsBundleHelper do
       expect(Plist::Emit).to receive(:save_plist)
 
       # code under test
-      helper.update_settings_plist_title_setting project, "Root.plist",
+      helper.update_settings_plist_title_setting project, "Settings.bundle", "Root.plist",
+                                                 "CurrentAppVersion", "1.0.0 (1)"
+    end
+
+    it 'finds a custom settings bundle by name' do
+      # Contents of Root.plist
+      preferences = {
+        "PreferenceSpecifiers" => [
+          {
+            "Type" => "PSTitleValueSpecifier",
+            "Key" => "CurrentAppVersion"
+          }
+        ]
+      }
+
+      # mock file
+      settings_bundle = double "file", path: "MySettings.bundle", real_path: "/path/to/MySettings.bundle"
+
+      # mock project
+      project = double "project",
+                       files: [settings_bundle],
+                       path: "/a/b/c/MyProject.xcodeproj"
+
+      # mock out the file read
+      mock_file = double "File"
+      expect(File).to receive(:open).and_yield mock_file
+      expect(Plist).to receive(:parse_xml) { preferences }
+
+      # and write
+      expect(Plist::Emit).to receive(:save_plist)
+
+      # code under test
+      helper.update_settings_plist_title_setting project, "MySettings.bundle", "Root.plist",
                                                  "CurrentAppVersion", "1.0.0 (1)"
     end
 
@@ -278,7 +310,7 @@ describe Fastlane::Helper::SettingsBundleHelper do
       project = double "project", files: []
 
       expect do
-        helper.update_settings_plist_title_setting project, "Root.plist",
+        helper.update_settings_plist_title_setting project, "Settings.bundle", "Root.plist",
                                                    "CurrentAppVersion", "1.0.0 (1)"
       end.to raise_error RuntimeError
     end
@@ -298,7 +330,7 @@ describe Fastlane::Helper::SettingsBundleHelper do
       expect(Plist).to receive(:parse_xml) { nil }
 
       expect do
-        helper.update_settings_plist_title_setting project, "Root.plist",
+        helper.update_settings_plist_title_setting project, "Settings.bundle", "Root.plist",
                                                    "CurrentAppVersion", "1.0.0 (1)"
       end.to raise_error RuntimeError
     end
@@ -318,7 +350,7 @@ describe Fastlane::Helper::SettingsBundleHelper do
       expect(Plist).to receive(:parse_xml) { {} }
 
       expect do
-        helper.update_settings_plist_title_setting project, "Root.plist",
+        helper.update_settings_plist_title_setting project, "Settings.bundle", "Root.plist",
                                                    "CurrentAppVersion", "1.0.0 (1)"
       end.to raise_error RuntimeError
     end
@@ -341,7 +373,7 @@ describe Fastlane::Helper::SettingsBundleHelper do
       expect(Plist).to receive(:parse_xml) { preferences }
 
       expect do
-        helper.update_settings_plist_title_setting project, "Root.plist",
+        helper.update_settings_plist_title_setting project, "Settings.bundle", "Root.plist",
                                                    "CurrentAppVersion", "1.0.0 (1)"
       end.to raise_error RuntimeError
     end
@@ -371,7 +403,7 @@ describe Fastlane::Helper::SettingsBundleHelper do
       expect(Plist).to receive(:parse_xml) { preferences }
 
       expect do
-        helper.update_settings_plist_title_setting project, "Root.plist",
+        helper.update_settings_plist_title_setting project, "Settings.bundle", "Root.plist",
                                                    "CurrentAppVersion", "1.0.0 (1)"
       end.to raise_error RuntimeError
     end

--- a/spec/update_settings_bundle_action_spec.rb
+++ b/spec/update_settings_bundle_action_spec.rb
@@ -33,11 +33,11 @@ describe Fastlane::Actions::UpdateSettingsBundleAction do
       expect(helper).to receive(:formatted_value).with(":version (:build)", settings) { "1.0.0 (1)" }
 
       expect(helper).to receive(:update_settings_plist_title_setting)
-        .with project, "Root.plist", "CurrentAppVersion", "1.0.0 (1)"
+        .with project, "Settings.bundle", "Root.plist", "CurrentAppVersion", "1.0.0 (1)"
 
       action.run xcodeproj: "MyProject.xcodeproj", key: "CurrentAppVersion",
         configuration: "Release", file: "Root.plist",
-        value: ":version (:build)", target: "MyAppTarget"
+        value: ":version (:build)", target: "MyAppTarget", bundle_name: "Settings.bundle"
     end
 
     it 'logs on error' do
@@ -66,7 +66,7 @@ describe Fastlane::Actions::UpdateSettingsBundleAction do
 
     it 'has the right number of options' do
       # reminder to add tests for any new options
-      expect(options.count).to equal(6)
+      expect(options.count).to equal(7)
     end
 
     it 'includes a :xcodeproj option' do
@@ -91,6 +91,10 @@ describe Fastlane::Actions::UpdateSettingsBundleAction do
 
     it 'includes a :target option' do
       expect(options.find { |o| o.key == :target && o.env_name == "SETTINGS_BUNDLE_TARGET" }).not_to be_nil
+    end
+
+    it 'includes a :bundle_name option' do
+      expect(options.find { |o| o.key == :bundle_name && o.env_name == "SETTINGS_BUNDLE_BUNDLE_NAME" }).not_to be_nil
     end
   end
 


### PR DESCRIPTION
Fix #10.

This next release will break `commit_version_bump` anyway, so this is a good time to add a `:bundle_name` parameter:

```ruby
update_settings_bundle(
  xcodeproj: "MyProject.xcodeproj",
  key: "CurrentAppVersion",
  value: ":version (:build)",
  bundle_name: "MySettings.bundle"
)
```