### PR TITLE
Made :xcodeproj parameter optional (#9)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-settings_bundle (1.1.2)
+    fastlane-plugin-settings_bundle (1.2.0)
       plist
       xcodeproj (>= 1.4.0)
 
@@ -191,4 +191,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ the current build number.
 
 ```ruby
 update_settings_bundle(
-  xcodeproj: "MyProject.xcodeproj",
   key: "CurrentAppVersion",
   value: ":version (:build)"
 )
@@ -41,11 +40,24 @@ specified format. Use the action this way after `increment_build_number` or
 `increment_version_number` to update your settings bundle as part of a
 version bump.
 
+#### Specifying the project file
+
+By default, the action looks for a single .xcodeproj file in the repo,
+excluding any under Pods. If more than one is present, use the `:xcodeproj`
+parameter:
+
+```ruby
+update_settings_bundle(
+  xcodeproj: "./MyProject.xcodeproj",
+  key: "CurrentAppVersion",
+  value: ":version (:build)"
+)
+```
+
 #### Files other than Root.plist
 
 ```ruby
 update_settings_bundle(
-  xcodeproj: "MyProject.xcodeproj",
   file: "About.plist",
   key: "CurrentAppVersion",
   value: ":version (:build)"
@@ -65,7 +77,6 @@ other settings besides the version and build numbers.
 
 ```ruby
 update_settings_bundle(
-  xcodeproj: "MyProject.xcodeproj",
   key: "BuildDate",
   value: Time.now.strftime("%Y-%m-%d")
 )
@@ -81,7 +92,6 @@ different configuration, use a `configuration` parameter:
 
 ```ruby
 update_settings_bundle(
-  xcodeproj: "MyProject.xcodeproj",
   key: "CurrentAppVersion",
   value: ":version (:build)",
   configuration: "Debug"
@@ -94,7 +104,6 @@ By default, this action takes the settings from the first non-test, non-extensio
 the project. Use the optional :target parameter to specify a target by name.
 ```ruby
 update_settings_bundle(
-  xcodeproj: "MyProject.xcodeproj",
   key: "CurrentAppVersion",
   value: ":version (:build)",
   target: "MyAppTarget"
@@ -107,7 +116,6 @@ By default, this action looks for a file called `Settings.bundle` in the project
 specify a different name for your settings bundle, use the `:bundle_name` option:
 ```ruby
 update_settings_bundle(
-  xcodeproj: "MyProject.xcodeproj",
   key: "CurrentAppVersion",
   value: ":version (:build)",
   bundle_name: "MySettings.bundle"

--- a/lib/fastlane/plugin/settings_bundle/actions/update_settings_bundle_action.rb
+++ b/lib/fastlane/plugin/settings_bundle/actions/update_settings_bundle_action.rb
@@ -28,10 +28,14 @@ module Fastlane
         file = params[:file]
         value = params[:value]
 
-        # try to open project file (raises)
-        project = Xcodeproj::Project.open params[:xcodeproj]
-
         helper = Helper::SettingsBundleHelper
+
+        xcodeproj_path = helper.xcodeproj_path_from_params params
+        # Error already reported in helper
+        return if xcodeproj_path.nil?
+
+        # try to open project file (raises)
+        project = Xcodeproj::Project.open xcodeproj_path
 
         # raises
         settings = helper.settings_from_project project, configuration, target_name
@@ -64,11 +68,6 @@ module Fastlane
       def self.available_options
         [
           # Required parameters
-          FastlaneCore::ConfigItem.new(key: :xcodeproj,
-                                  env_name: "SETTINGS_BUNDLE_XCODEPROJ",
-                               description: "An Xcode project file whose settings bundle to update",
-                                  optional: false,
-                                      type: String),
           FastlaneCore::ConfigItem.new(key: :key,
                                   env_name: "SETTINGS_BUNDLE_KEY",
                                description: "The user defaults key to update in the settings bundle",
@@ -81,6 +80,11 @@ module Fastlane
                                       type: String),
 
           # Optional parameters
+          FastlaneCore::ConfigItem.new(key: :xcodeproj,
+                                  env_name: "SETTINGS_BUNDLE_XCODEPROJ",
+                               description: "An Xcode project file whose settings bundle to update",
+                                  optional: true,
+                                      type: String),
           FastlaneCore::ConfigItem.new(key: :configuration,
                                   env_name: "SETTINGS_BUNDLE_CONFIGURATION",
                                description: "The build configuration to use for the Info.plist file",
@@ -111,7 +115,6 @@ module Fastlane
         [
           <<-EOF
             update_settings_bundle(
-              xcodeproj: "MyProject.xcodeproj",
               key: "CurrentAppVersion",
               value: ":version (:build)"
             )
@@ -119,6 +122,12 @@ module Fastlane
           <<-EOF
             update_settings_bundle(
               xcodeproj: "MyProject.xcodeproj",
+              key: "CurrentAppVersion",
+              value: ":version (:build)"
+            )
+          EOF,
+          <<-EOF
+            update_settings_bundle(
               file: "About.plist",
               key: "CurrentAppVersion",
               value: ":version (:build)"
@@ -126,14 +135,12 @@ module Fastlane
           EOF,
           <<-EOF
             update_settings_bundle(
-              xcodeproj: "MyProject.xcodeproj",
               key: "BuildDate",
               value: Time.now.strftime("%Y-%m-%d")
             )
           EOF,
           <<-EOF
             update_settings_bundle(
-              xcodeproj: "MyProject.xcodeproj",
               key: "CurrentAppVersion",
               value: ":version (:build)",
               configuration: "Debug"
@@ -141,7 +148,6 @@ module Fastlane
           EOF,
           <<-EOF
             update_settings_bundle(
-              xcodeproj: "MyProject.xcodeproj",
               key: "CurrentAppVersion",
               value: ":version (:build)",
               target: "MyAppTarget"
@@ -149,7 +155,6 @@ module Fastlane
           EOF,
           <<-EOF
             update_settings_bundle(
-              xcodeproj: "MyProject.xcodeproj",
               key: "CurrentAppVersion",
               value: ":version (:build)",
               bundle_name: "MySettings.bundle"

--- a/lib/fastlane/plugin/settings_bundle/helper/settings_bundle_helper.rb
+++ b/lib/fastlane/plugin/settings_bundle/helper/settings_bundle_helper.rb
@@ -131,6 +131,34 @@ module Fastlane
           # Save (raises)
           Plist::Emit.save_plist settings_plist, plist_path
         end
+
+        def xcodeproj_path_from_params(params)
+          return params[:xcodeproj] if params[:xcodeproj]
+
+          # Adapted from commit_version_bump
+          # https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/commit_version_bump.rb#L21
+
+          # This may not be a git project. Search relative to the Gemfile.
+          repo_path = Bundler.root
+
+          all_xcodeproj_paths = Dir[File.expand_path(File.join(repo_path, '**/*.xcodeproj'))]
+          # find an xcodeproj (ignoring the Cocoapods one)
+          xcodeproj_paths = Fastlane::Actions.ignore_cocoapods_path(all_xcodeproj_paths)
+
+          # no projects found: error
+          UI.user_error!('Could not find a .xcodeproj in the current repository\'s working directory.') and return nil if xcodeproj_paths.count == 0
+
+          # too many projects found: error
+          if xcodeproj_paths.count > 1
+            repo_pathname = Pathname.new repo_path
+            relative_projects = xcodeproj_paths.map { |e| Pathname.new(e).relative_path_from(repo_pathname).to_s }.join("\n")
+            UI.user_error!("Found multiple .xcodeproj projects in the current repository's working directory. Please specify your app's main project: \n#{relative_projects}")
+            return nil
+          end
+
+          # one project found: great
+          xcodeproj_paths.first
+        end
       end
     end
   end

--- a/spec/settings_bundle_helper_spec.rb
+++ b/spec/settings_bundle_helper_spec.rb
@@ -408,4 +408,34 @@ describe Fastlane::Helper::SettingsBundleHelper do
       end.to raise_error RuntimeError
     end
   end
+
+  describe 'xcodeproj_path_from_params' do
+    let (:root) { Bundler.root }
+
+    it 'returns the :xcodeproj parameter if present' do
+      expect(helper.xcodeproj_path_from_params(xcodeproj: "./MyProject.xcodeproj")).to eq "./MyProject.xcodeproj"
+    end
+
+    it 'returns the path if one project present' do
+      expect(Dir).to receive(:[]) { ["#{root}/MyProject.xcodeproj"] }
+      expect(helper.xcodeproj_path_from_params({})).to eq "#{root}/MyProject.xcodeproj"
+    end
+
+    it 'ignores projects under Pods' do
+      expect(Dir).to receive(:[]) { ["#{root}/MyProject.xcodeproj", "#{root}/Pods/Pods.xcodeproj"] }
+      expect(helper.xcodeproj_path_from_params({})).to eq "#{root}/MyProject.xcodeproj"
+    end
+
+    it 'returns nil and errors if no project found' do
+      expect(Dir).to receive(:[]) { [] }
+      expect(FastlaneCore::UI).to receive(:user_error!)
+      expect(helper.xcodeproj_path_from_params({})).to be_nil
+    end
+
+    it 'returns the path if one project present' do
+      expect(Dir).to receive(:[]) { ["#{root}/MyProject.xcodeproj", "#{root}/OtherProject.xcodeproj"] }
+      expect(FastlaneCore::UI).to receive(:user_error!)
+      expect(helper.xcodeproj_path_from_params({})).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Adopted the approach used in `commit_version_bump`: Look for one .xcodeproj somewhere in the repo, with the exception of those under Pods. If one found, use that. An error is reported if there is none or more than one. The `:xcodeproj` parameter is now optional and can be used to specify when necessary.