### PR TITLE
Macro fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-settings_bundle (1.2.1)
+    fastlane-plugin-settings_bundle (1.2.2)
       plist
       xcodeproj (>= 1.4.0)
 

--- a/spec/settings_bundle_helper_spec.rb
+++ b/spec/settings_bundle_helper_spec.rb
@@ -482,10 +482,7 @@ describe Fastlane::Helper::SettingsBundleHelper do
     end
 
     it "balances delimiters" do
-      pending "sort out the regex matching"
       expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_NESTED_VALUES") { { "Release" => "$(SETTING_VALUE1}.${SETTING_VALUE2)" } }
-      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE1") { { "Release" => "value1" } }
-      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE2") { { "Release" => "value2" } }
       expect(helper.expanded_build_setting(target, "SETTING_WITH_NESTED_VALUES", "Release")).to eq "$(SETTING_VALUE1}.${SETTING_VALUE2)"
     end
 
@@ -494,6 +491,13 @@ describe Fastlane::Helper::SettingsBundleHelper do
       expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE1") { { "Release" => "$(SETTING_VALUE2)" } }
       expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE2") { { "Release" => "value2" } }
       expect(helper.expanded_build_setting(target, "SETTING_WITH_NESTED_VALUES", "Release")).to eq "value2"
+    end
+
+    it "returns the unexpanded macro for nonexistent settings" do
+      expect(target).to receive(:resolved_build_setting).with("SETTING_WITH_BOGUS_VALUE") { { "Release" => "$(SETTING_VALUE1).$(SETTING_VALUE2)" } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE1") { { "Release" => nil } }
+      expect(target).to receive(:resolved_build_setting).with("SETTING_VALUE2") { { "Release" => "value2" } }
+      expect(helper.expanded_build_setting(target, "SETTING_WITH_BOGUS_VALUE", "Release")).to eq "$(SETTING_VALUE1).value2"
     end
   end
 end

--- a/spec/settings_bundle_helper_spec.rb
+++ b/spec/settings_bundle_helper_spec.rb
@@ -134,7 +134,7 @@ describe Fastlane::Helper::SettingsBundleHelper do
                       extension_target_type?: false
 
       expect(target).to receive(:resolved_build_setting)
-        .with("INFOPLIST_FILE") { nil }
+        .with("INFOPLIST_FILE") { { "Release" => nil } }
 
       # mock project
       project = double "project", targets: [target], path: ""


### PR DESCRIPTION
- Fix delimiter balance issues ($(SRCROOT} and ${SRCROOT) will no longer be expanded)
- Improve handling of lookup failures, e.g. $(FOO), where FOO is not defined in the project. The unexpanded macro is returned. Previously there was an infinite recursion.

This probably doesn't have a lot of practical impact. It will be included in the next release.