### PR TITLE
Add 'remove_setting' action to remove setting items by key

### DIFF
--- a/lib/fastlane/plugin/settings_bundle/actions/remove_setting_action.rb
+++ b/lib/fastlane/plugin/settings_bundle/actions/remove_setting_action.rb
@@ -1,0 +1,125 @@
+# Copyright (c) 2016-17 Jimmy Dee
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+module Fastlane
+  module Actions
+    class RemoveSettingAction < Action
+      def self.run(params)
+        key = params[:key]
+        file = params[:file]
+
+        helper = Helper::SettingsBundleHelper
+
+        xcodeproj_path = helper.xcodeproj_path_from_params params
+        # Error already reported in helper
+        return if xcodeproj_path.nil?
+
+        # try to open project file (raises)
+        project = Xcodeproj::Project.open xcodeproj_path      
+
+        # raises
+        helper.remove_settings_plist_title_setting project, params[:bundle_name], file, key
+
+      rescue => e
+        UI.user_error! "#{e.message}\n#{e.backtrace}"
+      end
+
+      def self.description
+        "Fastlane plugin action to remove settings in an iOS settings bundle"
+      end
+
+      def self.author
+        "Colin Harris"
+      end
+
+      def self.details
+        "This action is used to automatically delete an entry \n" \
+          "in an app's Settings bundle. It can be used to remove settings \n." \
+          "that you do not want to make available in some environments."
+      end
+
+      def self.available_options
+        [
+          # Required parameters
+          FastlaneCore::ConfigItem.new(key: :key,
+                                  env_name: "SETTINGS_BUNDLE_KEY",
+                               description: "The user defaults key to update in the settings bundle",
+                                  optional: false,
+                                      type: String),          
+
+          # Optional parameters
+          FastlaneCore::ConfigItem.new(key: :xcodeproj,
+                                  env_name: "SETTINGS_BUNDLE_XCODEPROJ",
+                               description: "An Xcode project file whose settings bundle to update",
+                                  optional: true,
+                                      type: String),
+          FastlaneCore::ConfigItem.new(key: :file,
+                                  env_name: "SETTINGS_BUNDLE_FILE",
+                               description: "The plist file in the Settings.bundle to update",
+                                  optional: true,
+                             default_value: "Root.plist",
+                                      type: String),
+          FastlaneCore::ConfigItem.new(key: :bundle_name,
+                                  env_name: "SETTINGS_BUNDLE_BUNDLE_NAME",
+                               description: "The name of the settings bundle in the project (default Settings.bundle)",
+                                  optional: true,
+                             default_value: "Settings.bundle",
+                                      type: String)
+        ]
+      end
+
+      def self.example_code
+        [
+          <<-EOF
+            remove_setting(
+              key: "ItemToRemove"
+            )
+          EOF,
+          <<-EOF
+            remove_setting(
+              xcodeproj: "MyProject.xcodeproj",
+              key: "ItemToRemove",
+            )
+          EOF,
+          <<-EOF
+            remove_setting(
+              file: "About.plist",
+              key: "ItemToRemove"
+            )
+          EOF,                    
+          <<-EOF
+            remove_setting(
+              key: "ItemToRemove",
+              bundle_name: "MySettings.bundle"
+            )
+          EOF
+        ]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+
+      def self.category
+        :project
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/settings_bundle/helper/settings_bundle_helper.rb
+++ b/lib/fastlane/plugin/settings_bundle/helper/settings_bundle_helper.rb
@@ -127,6 +127,47 @@ module Fastlane
           Plist::Emit.save_plist settings_plist, plist_path
         end
 
+        # Takes an open Xcodeproj::Project, extracts the settings bundle
+        # and removes the specified setting key in the specified file.
+        # Raises on error.
+        #
+        # :project: An open Xcodeproj::Project, obtained from Xcodeproj::Project.open, e.g.
+        # :bundle_name: (String) Regex to identify the bundle to look for, usually Settings.bundle.
+        # :file: A settings plist file in the Settings.bundle, usually "Root.plist"
+        # :key: A valid NSUserDefaults key in the Settings.bundle
+        def remove_settings_plist_title_setting(project, bundle_name, file, key)
+          settings_bundle = project.files.find { |f| f.path =~ /#{bundle_name}/ }
+
+          raise "#{bundle_name} not found in project" if settings_bundle.nil?
+
+          # The #real_path method returns the full resolved path to the Settings.bundle
+          settings_bundle_path = settings_bundle.real_path
+
+          plist_path = File.join settings_bundle_path, file
+
+          # raises IOError
+          settings_plist = File.open(plist_path) { |f| Plist.parse_xml f }
+
+          raise "Could not parse #{plist_path}" if settings_plist.nil?
+
+          preference_specifiers = settings_plist["PreferenceSpecifiers"]
+          raise "#{file} is not a settings plist file" if preference_specifiers.nil?
+
+          original_count = preference_specifiers.length          
+
+          raise "#{file} is not a settings plist file" if preference_specifiers.nil?
+
+          # Remove the specifier matching the supplied key
+          settings_plist["PreferenceSpecifiers"] = preference_specifiers.select do |specifier|
+            specifier["Key"] != key
+          end
+
+          raise "preference specifier for key #{key} not found in #{file}" if settings_plist["PreferenceSpecifiers"].length == original_count
+
+          # Save (raises)
+          Plist::Emit.save_plist settings_plist, plist_path
+        end
+
         def xcodeproj_path_from_params(params)
           return params[:xcodeproj] if params[:xcodeproj]
 

--- a/spec/remove_setting_action_spec.rb
+++ b/spec/remove_setting_action_spec.rb
@@ -1,0 +1,106 @@
+# Copyright (c) 2016-17 Jimmy Dee
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+describe Fastlane::Actions::RemoveSettingAction do
+  let (:action) { Fastlane::Actions::RemoveSettingAction }
+
+  describe '#run' do
+    it 'calls the appropriate helper methods' do
+      project = double "project"
+      expect(Xcodeproj::Project).to receive(:open).with("MyProject.xcodeproj") { project }
+
+      helper = Fastlane::Helper::SettingsBundleHelper
+
+      expect(helper).to receive(:remove_settings_plist_title_setting)
+        .with project, "Settings.bundle", "Root.plist", "ItemToRemove"
+
+      action.run xcodeproj: "MyProject.xcodeproj", key: "ItemToRemove",
+        file: "Root.plist", bundle_name: "Settings.bundle"
+    end
+
+    it 'logs on error' do
+      expect(Xcodeproj::Project).to receive(:open).and_raise "Not found"
+
+      expect(FastlaneCore::UI).to receive(:user_error!).with(/Not found/)
+
+      action.run xcodeproj: "MyProject.xcodeproj"
+    end
+  end
+
+  describe 'OS support' do
+    it 'is supported on iOS' do
+      expect(action.is_supported?(:ios)).to be true
+    end
+  end
+
+  describe 'category' do
+    it 'is in the :project category' do
+      expect(action.category).to eq(:project)
+    end
+  end
+
+  describe 'options' do
+    let(:options) { action.available_options }
+
+    it 'has the right number of options' do
+      # reminder to add tests for any new options
+      expect(options.count).to equal(4)
+    end
+
+    it 'includes a :xcodeproj option' do
+      expect(options.find { |o| o.key == :xcodeproj && o.env_name == "SETTINGS_BUNDLE_XCODEPROJ" }).not_to be_nil
+    end
+
+    it 'includes a :key option' do
+      expect(options.find { |o| o.key == :key && o.env_name == "SETTINGS_BUNDLE_KEY" }).not_to be_nil
+    end
+
+    it 'includes a :file option' do
+      expect(options.find { |o| o.key == :file && o.env_name == "SETTINGS_BUNDLE_FILE" }).not_to be_nil
+    end
+    
+    it 'includes a :bundle_name option' do
+      expect(options.find { |o| o.key == :bundle_name && o.env_name == "SETTINGS_BUNDLE_BUNDLE_NAME" }).not_to be_nil
+    end
+  end
+
+  # Satisfy simplecov
+  describe 'other methods' do
+    it 'has examples' do
+      expect(action.example_code).not_to be nil
+    end
+
+    it 'has options' do
+      expect(action.available_options).not_to be nil
+    end
+
+    it 'has details' do
+      expect(action.details).not_to be nil
+    end
+
+    it 'has an author' do
+      expect(action.author).not_to be nil
+    end
+
+    it 'has a description' do
+      expect(action.description).not_to be nil
+    end
+  end
+end

--- a/spec/settings_bundle_helper_spec.rb
+++ b/spec/settings_bundle_helper_spec.rb
@@ -409,6 +409,144 @@ describe Fastlane::Helper::SettingsBundleHelper do
     end
   end
 
+  describe 'remove_settings_plist_title_setting' do
+    it 'removes the item from the Settings.bundle as specified' do
+      # Contents of Root.plist
+      preferences = {
+        "PreferenceSpecifiers" => [
+          {
+            "Type" => "PSTitleValueSpecifier",
+            "Key" => "ItemToRemove"
+          }
+        ]
+      }
+
+      # mock file
+      settings_bundle = double "file", path: "Settings.bundle", real_path: "/path/to/Settings.bundle"
+
+      # mock project
+      project = double "project",
+                       files: [settings_bundle],
+                       path: "/a/b/c/MyProject.xcodeproj"
+
+      # mock out the file read
+      mock_file = double "File"
+      expect(File).to receive(:open).and_yield mock_file
+      expect(Plist).to receive(:parse_xml) { preferences }
+
+      # and write
+      expect(Plist::Emit).to receive(:save_plist)
+
+      # code under test
+      helper.remove_settings_plist_title_setting project, "Settings.bundle", "Root.plist",
+                                                 "ItemToRemove"
+    end
+
+    it 'finds a custom settings bundle by name' do
+      # Contents of Root.plist
+      preferences = {
+        "PreferenceSpecifiers" => [
+          {
+            "Type" => "PSTitleValueSpecifier",
+            "Key" => "ItemToRemove"
+          }
+        ]
+      }
+
+      # mock file
+      settings_bundle = double "file", path: "MySettings.bundle", real_path: "/path/to/MySettings.bundle"
+
+      # mock project
+      project = double "project",
+                       files: [settings_bundle],
+                       path: "/a/b/c/MyProject.xcodeproj"
+
+      # mock out the file read
+      mock_file = double "File"
+      expect(File).to receive(:open).and_yield mock_file
+      expect(Plist).to receive(:parse_xml) { preferences }
+
+      # and write
+      expect(Plist::Emit).to receive(:save_plist)
+
+      # code under test
+      helper.remove_settings_plist_title_setting project, "MySettings.bundle", "Root.plist",
+                                                 "ItemToRemove"
+    end
+
+    it 'raises if no Settings.bundle in project' do
+      project = double "project", files: []
+
+      expect do
+        helper.remove_settings_plist_title_setting project, "Settings.bundle", "Root.plist",
+                                                   "ItemToRemove"
+      end.to raise_error RuntimeError
+    end
+
+    it 'raises if the settings plist file cannot be parsed' do
+      # mock file
+      settings_bundle = double "file", path: "Settings.bundle", real_path: "/path/to/Settings.bundle"
+
+      # mock project
+      project = double "project",
+                       files: [settings_bundle],
+                       path: "/a/b/c/MyProject.xcodeproj"
+
+      # mock nil return
+      mock_file = double "File"
+      expect(File).to receive(:open).and_yield mock_file
+      expect(Plist).to receive(:parse_xml) { nil }
+
+      expect do
+        helper.remove_settings_plist_title_setting project, "Settings.bundle", "Root.plist",
+                                                   "ItemToRemove"
+      end.to raise_error RuntimeError
+    end
+
+    it 'raises if PreferenceSpecifiers not found in plist' do
+      # mock file
+      settings_bundle = double "file", path: "Settings.bundle", real_path: "/path/to/Settings.bundle"
+
+      # mock project
+      project = double "project",
+                       files: [settings_bundle],
+                       path: "/a/b/c/MyProject.xcodeproj"
+
+      # mock out the file read
+      mock_file = double "File"
+      expect(File).to receive(:open).and_yield mock_file
+      expect(Plist).to receive(:parse_xml) { {} }
+
+      expect do
+        helper.remove_settings_plist_title_setting project, "Settings.bundle", "Root.plist",
+                                                   "ItemToRemove"
+      end.to raise_error RuntimeError
+    end
+
+    it 'raises if specified key not found' do
+      # Contents of Root.plist
+      preferences = { "PreferenceSpecifiers" => [] }
+
+      # mock file
+      settings_bundle = double "file", path: "Settings.bundle", real_path: "/path/to/Settings.bundle"
+
+      # mock project
+      project = double "project",
+                       files: [settings_bundle],
+                       path: "/a/b/c/MyProject.xcodeproj"
+
+      # mock out the file read
+      mock_file = double "File"
+      expect(File).to receive(:open).and_yield mock_file
+      expect(Plist).to receive(:parse_xml) { preferences }
+
+      expect do
+        helper.remove_settings_plist_title_setting project, "Settings.bundle", "Root.plist",
+                                                   "ItemToRemove"
+      end.to raise_error RuntimeError
+    end
+  end
+
   describe 'xcodeproj_path_from_params' do
     let (:root) { Bundler.root }
 


### PR DESCRIPTION
The iOS doesn't provide the ability to remove, hide or disable settings in the Settings.bundle dynamically. To achieve this task I've added a new action to allow Settings items to be removed by specifying the key. This can be used to remove some setting options when building an app for a particular environment or release.

```
remove_setting(
  xcodeproj: 'MyApp.xcodeproj,
  key: 'ItemToRemove'
)
```