### PR TITLE
Only call add_modified_files if it exists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ update_settings_bundle(
 
 ### Use with commit_version_bump
 
-As of version 1.3.0 (which requires Fastlane 2.64.0), it is no longer necessary
+As of version 1.3.0, it is no longer necessary
 to pass a `settings` parameter to the built-in `commit_version_bump` action
-when using `update_settings_bundle`.
+when using `update_settings_bundle` if you are using Fastlane >= 2.64.0.
 
 ```ruby
 increment_build_number

--- a/lib/fastlane/plugin/settings_bundle/helper/settings_bundle_helper.rb
+++ b/lib/fastlane/plugin/settings_bundle/helper/settings_bundle_helper.rb
@@ -126,7 +126,7 @@ module Fastlane
           # Save (raises)
           Plist::Emit.save_plist settings_plist, plist_path
 
-          Actions.add_modified_files [plist_path]
+          Actions.add_modified_files [plist_path] if Actions.respond_to? :add_modified_files
         end
 
         def xcodeproj_path_from_params(params)


### PR DESCRIPTION
Fastlane is only a dev dependency in this gem. It's possible for the latest release to be installed with an older version of Fastlane, so check for the existence of `Actions::add_modified_files` before calling it. When using Fastlane < 2.64.0, it will still be necessary to pass a `settings` argument to `commit_version_bump`.