### PR TITLE
Use XcodeprojHelper for finding Xcode projects

### DIFF
--- a/lib/fastlane/plugin/settings_bundle/helper/settings_bundle_helper.rb
+++ b/lib/fastlane/plugin/settings_bundle/helper/settings_bundle_helper.rb
@@ -138,9 +138,8 @@ module Fastlane
           # This may not be a git project. Search relative to the Gemfile.
           repo_path = Bundler.root
 
-          all_xcodeproj_paths = Dir[File.expand_path(File.join(repo_path, '**/*.xcodeproj'))]
-          # find an xcodeproj (ignoring the Cocoapods one)
-          xcodeproj_paths = Fastlane::Actions.ignore_cocoapods_path(all_xcodeproj_paths)
+          # find an xcodeproj (ignoring dependencies)
+          xcodeproj_paths = Fastlane::Helper::XcodeprojHelper.find(repo_path)
 
           # no projects found: error
           UI.user_error!('Could not find a .xcodeproj in the current repository\'s working directory.') and return nil if xcodeproj_paths.count == 0


### PR DESCRIPTION
Resolves #25.

This simply adopts the changes made to [commit_version_bump](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/commit_version_bump.rb#L21) by [#14000](https://github.com/fastlane/fastlane/pull/14000).

Let me know what you think! If you agree with the change, it would be great if this could be merged. 

The `settings-bundle` plugin is broken since Fastlane [2.113.0](https://github.com/fastlane/fastlane/pull/14000). 

We're currently using our own fork with this patch applied.